### PR TITLE
Resolved initialization.

### DIFF
--- a/examples/EratosthenesExampleSoftware.jl
+++ b/examples/EratosthenesExampleSoftware.jl
@@ -52,9 +52,8 @@ function StarTrackerAndGyroController()
                     jitl,             # Default operation mode
                     UDPConnection(ip"192.168.1.3", 2000, 2001))
 
-    # This function initializes any dependencies and provides initial "inputs"
-    # and "outputs".
-    function init(t, constants, state, args...)
+    # This function always runs before the simulation starts up.
+    function startup(t, constants, state, args...)
         if constants.mode == sitl
             if is_windows()
                 constants.c_lib = Libdl.dlopen("3_c_code/windows/lib-pd-controller.dll")
@@ -66,7 +65,6 @@ function StarTrackerAndGyroController()
             println("Connecting to remote computer.")
             udp_connect(constants.conn)
         end
-        return (state, true)
     end
 
     # This function is called each time the controller trigger time is reached.
@@ -145,7 +143,8 @@ function StarTrackerAndGyroController()
     end
 
     DynamicalModel("star_tracker_and_gyro_controller",
-                   init = init,
+                   startup = startup,
+                   init = step,
                    update = step,
                    shutdown = shutdown,
                    timing = ModelTiming(0.05),  # Sample rate

--- a/examples/scenarios/basic-cube.yaml
+++ b/examples/scenarios/basic-cube.yaml
@@ -5,20 +5,20 @@ sim:
   date_0: [2017, 6, 29, 17, 6, 32.2] # Simulation start date (UT1)
   log_file: out/basic-cube.h5
 environment:
-  model: LowEarthOrbit # Includes gravity, magnetic field, air density
+  model: LowEarthOrbit # Includes gravity, magnetic field, air density (or should environments be plural, and _each_ of these is a model?)
 vehicles:
   - model: Vehicle # Generic rigid body with inertial state
     name: cube1
-    body:
+    body: # No need to specify the model; the default body will do for us.
       constants:
         m: 55. # Mass of the body (kg); components can have their own masses via Mass effects
         I_B: [[5., 0., 0.],
               [0., 5., 0.],
               [0., 0., 5.]] # Central mass moment of inertia of the body (kg m^2)
-      state:
+      state: # state: (OrbitalElements(...), AttitudeType.LVLH())
         r_be_I: "[6378137.+350000., 0., 0.]" # Position of reference point b wrt COM of Earth in ICRF (m)
         v_be_I: "7600. * [0; cos(pi/4); sin(pi/4)]" # Rate of change of above (m/s)
-        q_BI:   "normalize([0.5; 1; 0.2; 0])" # Orientation of body wrt ICRF
+        q_BI:   "normalize([0.; 0.; 1.; 0.5])" # Orientation of body wrt ICRF
         ω_BI_B: [0., 0., 0.] # Rotation rate of body wrt ICRF, expressed in body (rad/s)
     components: # Low-level stuff, like sensors and actuators; these run "before" software on common timesteps.
       - model: Gyro # Generic gyro; uses finite difference of q_BI as average rate

--- a/examples/working-scenario-runner.jl
+++ b/examples/working-scenario-runner.jl
@@ -1,5 +1,5 @@
 # Make sure we're running from the examples directory.
-cd(@__DIR__())
+# cd(@__DIR__())
 
 reload("Eratosthenes")
 sleep(0.1)
@@ -11,7 +11,7 @@ using BenchmarkTools
 using Eratosthenes # Bring in the top-level sim environment.
 using Plots # For plotting (Pkg.add("Plots"); Pkg.add("PyPlot");)
 import HDF5 # For loading the log file (Pkg.add("HDF5");)
-import Juno # For the progress bar
+# import Juno # For the progress bar
 
 # Include a module that's not part of Eratosthenes itself. Anything we "use"
 # here will be visible during the setup portion of the scenario. So we can
@@ -21,31 +21,41 @@ using .EratosthenesExampleSoftware
 
 # Create the hierarchy of objects used by the sim.
 scenario = setup("scenarios/basic-cube.yaml")
-# scenario.sim.log_file = "";
 
+# # Just run it.
 # simulate(scenario)
 
+# # Profile it.
+# scenario.sim.log_file = "";
 # @profile simulate(scenario)
-# open("prof.txt", "w") do s
+# open("profiler.txt", "w") do s
 #     Profile.print(IOContext(s, :displaysize => (24, 500)))
 # end
 # Profile.clear()
 
+# Run it with text progress (e.g., from VS Code).
+simulate(scenario) do k, n
+    if k % 50 == 0
+        println(100*k/n, "% done.")
+    end
+    return true
+end
+
 # Create a Juno waitbar. This do-block syntax makes sure it gets "closed" even
 # if there's an error.
-Juno.progress(name="Simulating...") do progress_bar
-
-    # Run the simulation. Anything inside this do-block will be run at the
-    # beginning of every major time step. This is useful for updating a progress
-    # bar or a plot.
-    simulate(scenario) do k, n
-        if k % 30 == 0
-            Juno.progress(progress_bar, (k-1)/n) # Update Juno's progress bar.
-        end
-        return true # Return false to end the sim.
-    end
-
-end
+# Juno.progress(name="Simulating...") do progress_bar
+#
+#     # Run the simulation. Anything inside this do-block will be run at the
+#     # beginning of every major time step. This is useful for updating a progress
+#     # bar or a plot.
+#     simulate(scenario) do k, n
+#         if k % 30 == 0
+#             Juno.progress(progress_bar, (k-1)/n) # Update Juno's progress bar.
+#         end
+#         return true # Return false to end the sim.
+#     end
+#
+# end
 
 # Open the logs and plot some things.
 if !isempty(scenario.sim.log_file)
@@ -71,7 +81,8 @@ if !isempty(scenario.sim.log_file)
     #t_gyro = squeeze(t_gyro, 1)
 
     # Choose a friendly plotting package. PyPlot behaves nicely.
-    pyplot()
+    # pyplot()
+    plotlyjs()
 
     # Define each plot that we'll need.
     p1 = plot(t, q_BI.',
@@ -82,8 +93,8 @@ if !isempty(scenario.sim.log_file)
               ylabel = "Rotation Rate (deg/s)")
 
     # Save the individual plots before showing them together.
-    savefig(p1, "out/sim-results-q.png")
-    savefig(p2, "out/sim-results-ω.png")
+    # savefig(p1, "out/sim-results-q.png")
+    # savefig(p2, "out/sim-results-ω.png")
 
     # Display those plots as subplots using the default "2" layout. Put any
     # common descriptors here.

--- a/src/Eratosthenes.jl
+++ b/src/Eratosthenes.jl
@@ -55,7 +55,7 @@ mutable struct ModelTiming
     ModelTiming(dt = 0., t_start = 0., t_next = 0., count = 0) = new(dt, t_start, t_next, count)
 end
 
-mutable struct DynamicalModel{FI, FE, FD, FU, FS, DC, DS, DI, DO}
+mutable struct DynamicalModel{F0, FI, FE, FD, FU, FS, DC, DS, DI, DO}
 
     name::String # Actually used as a key in a dictionary, as well as for logging
 
@@ -66,6 +66,7 @@ mutable struct DynamicalModel{FI, FE, FD, FU, FS, DC, DS, DI, DO}
     # out of the mutable things, then we'll remove this parameterization here
     # but keep it for the immutable version for speed there.
     #
+    startup::F0 # Called to allow one to set up resources or whatever.
     init::FI # "Tell me what you produce."
     effects::FE # "Produce physical effects."
     derivatives::FD # "Tell me how the state is changing."
@@ -86,6 +87,7 @@ end
 
 # Create a convenience constructor with lots of defaults.
 DynamicalModel(name;
+               startup = nothing,
                init = nothing,
                effects = nothing,
                derivatives = nothing,
@@ -97,7 +99,7 @@ DynamicalModel(name;
                inputs = nothing,
                outputs = nothing,
                rand = RandSpec()) =
-    DynamicalModel(name, init, effects, derivatives, update, shutdown, timing, constants, state, inputs, outputs, rand)
+    DynamicalModel(name, startup, init, effects, derivatives, update, shutdown, timing, constants, state, inputs, outputs, rand)
 
 # Convenience constructors
 # Body(name, init, effects, derivatives, shutdown, timing, constants, state, rand = RandSpec()) =

--- a/src/effects.jl
+++ b/src/effects.jl
@@ -26,10 +26,10 @@ function find_effect(effects_bus::Dict{String, Tuple}, null_effect::T) where T
     for effects in values(effects_bus) # effects contains tuple of Effects from each component
         index = findfirst(e->isa(e, T), effects)
         if !iszero(index)
-            return (effects[index], index)
+            return (effects[index], true)
         end
     end
-    return (null_effect, 0)
+    return (null_effect, false)
 end
 
 # Find a single instance of an effect in a vector of effects.

--- a/src/software.jl
+++ b/src/software.jl
@@ -23,12 +23,13 @@ function IdealPDController()
 
         return (state,      # Updated state (none)
                 nothing,    # Outputs
-                inputs_bus, # Updated inputs bus
+                inputs_bus, # Updated inputs bus (this is not necessary)
                 true)       # Active
 
     end
 
     DynamicalModel("ideal_pd_controller",
+                   init = step,
                    update = step,
                    timing = ModelTiming(0.05),
                    constants = [0.; 0.; 0.; 1.]) # target quaternion


### PR DESCRIPTION
This strategy calls `init` to bring the state to t=0+. The sim then
begins. The `init` function can, where appropriate, just call `update`,
or it can do things like take random draws and set up states. When we
will later want to load a state from a log and start the sim there,
we'll load all of the states, inputs, and outputs, and then begin the
sim without calling `init`.